### PR TITLE
ignore multivalue fields that are undefined in redcap dd

### DIFF
--- a/redcap_importer/management/commands/redcap_change_report.py
+++ b/redcap_importer/management/commands/redcap_change_report.py
@@ -214,6 +214,8 @@ class Command(BaseCommand):
 
         for comment in output:
             print(comment)
+        if len(output) == 0:
+            print("no schema changes detected")
         return
 
     def process_field_entry(self, entry):

--- a/redcap_importer/models.py
+++ b/redcap_importer/models.py
@@ -422,7 +422,7 @@ class FieldMetadata(models.Model):
         if self.is_many_to_many:
             field_names = self._get_many_to_many_redcap_fields()
             for key, field_name in field_names.items():
-                if entry[field_name] == "1":
+                if entry.get(field_name) == "1":
                     app_name = self.instrument.project.connection.unique_name
                     model_name = "{}_{}_lookup".format(
                         self.instrument.get_django_model_name(), self.get_django_field_name()
@@ -437,7 +437,7 @@ class FieldMetadata(models.Model):
                     oLookupModel = LookupModel(**args)
                     oLookupModel.save()
         else:
-            if not self.unique_name in entry:
+            if self.unique_name not in entry:
                 # print('field missing from data: {}'.format(self.unique_name))
                 # there are fields that don't return a value because they are just a label or something
                 return


### PR DESCRIPTION
This is an issue we hadn't run into before.

On multi-select field, normally there is a Boolean column in the data for each select option. the Prevail project had a field with no associated columns. In this case, I have to just skip it since I have no data to work with.